### PR TITLE
Don't add .html extension to filename

### DIFF
--- a/doxytag2zealdb/doxytag.py
+++ b/doxytag2zealdb/doxytag.py
@@ -267,7 +267,7 @@ class fileTagProcessor(TagProcessorWithAutoStuffAndCompoundTagName):
             A string containing the correct documentation filename from the
             tag.
         '''
-        return super(fileTagProcessor, self).get_filename(tag) + '.html'
+        return super(fileTagProcessor, self).get_filename(tag)
 
 
 class namespaceTagProcessor(TagProcessorWithAutoStuffAndCompoundTagName):


### PR DESCRIPTION
While trying to [update](https://github.com/Kapeli/Dash-User-Contributions/pull/3084) QGIS docset, it appears that *doxytag2zealdb* add an extra *.hml* extension when it's not necessary. 

I used doxygen 1.8.20